### PR TITLE
build: pina versão pandas

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -16,3 +16,4 @@ dependencies:
     - minimap2
     - seqkit
     - bokeh==2.4.3
+    - pandas==1.5.3


### PR DESCRIPTION
Corrige o erro

```python
Traceback (most recent call last):
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1490, in array_func
    result = self.grouper._cython_operation(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 959, in _cython_operation
    return cy_op.cython_operation(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 657, in cython_operation
    return self._cython_op_ndim_compat(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 497, in _cython_op_ndim_compat
    return self._call_cython_op(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 541, in _call_cython_op
    func = self._get_cython_function(self.kind, self.how, values.dtype, is_numeric)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 173, in _get_cython_function
    raise NotImplementedError(
NotImplementedError: function is not implemented for this dtype: [how->mean,dtype->object]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 1692, in _ensure_numeric
    x = float(x)
ValueError: could not convert string to float: 'chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 1696, in _ensure_numeric
    x = complex(x)
ValueError: complex() arg is a malformed string

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/wf-cas9/bin/report.py", line 455, in <module>
    main()
  File "/data/wf-cas9/bin/report.py", line 433, in main
    make_target_summary_table(report, args.sample_ids, args.target_summary,
  File "/data/wf-cas9/bin/report.py", line 212, in make_target_summary_table
    read_len = df_on_off.groupby(['target']).mean()[['read_length']]
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1855, in mean
    result = self._cython_agg_general(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1507, in _cython_agg_general
    new_mgr = data.grouped_reduce(array_func)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/internals/managers.py", line 1503, in grouped_reduce
    applied = sb.apply(func)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/internals/blocks.py", line 329, in apply
    result = func(self.values, **kwargs)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1503, in array_func
    result = self._agg_py_fallback(values, ndim=data.ndim, alt=alt)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1457, in _agg_py_fallback
    res_values = self.grouper.agg_series(ser, alt, preserve_dtype=True)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 994, in agg_series
    result = self._aggregate_series_pure_python(obj, func)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 1015, in _aggregate_series_pure_python
    res = func(group)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1857, in <lambda>
    alt=lambda x: Series(x).mean(numeric_only=numeric_only),
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/generic.py", line 11556, in mean
    return NDFrame.mean(self, axis, skipna, numeric_only, **kwargs)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/generic.py", line 11201, in mean
    return self._stat_function(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/generic.py", line 11158, in _stat_function
    return self._reduce(
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/series.py", line 4666, in _reduce
    return op(delegate, skipna=skipna, **kwds)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 96, in _f
    return f(*args, **kwargs)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 158, in f
    result = alt(values, axis=axis, skipna=skipna, **kwds)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 421, in new_func
    result = func(values, axis=axis, skipna=skipna, mask=mask, **kwargs)
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 727, in nanmean
    the_sum = _ensure_numeric(values.sum(axis, dtype=dtype_sum))
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/nanops.py", line 1699, in _ensure_numeric
    raise TypeError(f"Could not convert {x} to numeric") from err
TypeError: Could not convert chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2chr2 to numeric
```

Sendo essa a parte relevante:

```python
  File "/data/work/conda/epi2melabs-wf-cas9-e16d55f65a875f9075efd6576df63c51/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 173, in _get_cython_function
    raise NotImplementedError(
NotImplementedError: function is not implemented for this dtype: [how->mean,dtype->object]
```

Pandas passou por uma grande atualização (1.5.3 -> 2.0.1), quebrando retrocompatibilidade.

![image](https://user-images.githubusercontent.com/13784115/235419709-b62badb4-fac8-447b-9814-1a434e20bf31.png)

No screenshot abaixo, a provável causa do erro.

![image](https://user-images.githubusercontent.com/13784115/235419766-ea7045df-dfa4-4a39-9df0-22701b9abf23.png)

Issue relacionado: https://github.com/pandas-dev/pandas/issues/52930